### PR TITLE
Power Armor MK4: Declare dep on Power Armor MK3

### DIFF
--- a/Power Armor MK4/info.json
+++ b/Power Armor MK4/info.json
@@ -1,10 +1,10 @@
 {
 	"name":"Power Armor MK4",
 	"author":"zifnab06",
-	"version":"0.0.4",
+	"version":"0.0.5",
 	"title":"Power Armor MK4",
 	"description":"Even Bigger, even better power armor; with a gigantic grid (40x40) and huge inventory bonus (+200).",
 	"homepage":"nope",
 	"factorio_version":"0.15",
-	"dependencies": ["base >= 0.15.0"]
+	"dependencies": ["base >= 0.15.0", "Power Armor MK3 >= 0.1.2"]
 }


### PR DESCRIPTION
This is useful for things like fac, which will fetch dependencies automatically.